### PR TITLE
feat: log recommendation to switch to vite-plugin-react-oxc when rolldown-vite is detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ See [`@vitejs/plugin-react` documentation](packages/plugin-react/README.md) and 
 | Package                                               | Version (click for changelogs)                                                                                                             |
 | ----------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------- |
 | [@vitejs/plugin-react](packages/plugin-react)         | [![plugin-react version](https://img.shields.io/npm/v/@vitejs/plugin-react.svg?label=%20)](packages/plugin-react/CHANGELOG.md)             |
+| [@vitejs/plugin-react-oxc](packages/plugin-react-oxc) | [![plugin-react-oxc version](https://img.shields.io/npm/v/@vitejs/plugin-react-oxc.svg?label=%20)](packages/plugin-react-oxc/CHANGELOG.md) |
 | [@vitejs/plugin-react-swc](packages/plugin-react-swc) | [![plugin-react-swc version](https://img.shields.io/npm/v/@vitejs/plugin-react-swc.svg?label=%20)](packages/plugin-react-swc/CHANGELOG.md) |
 
 ## License

--- a/packages/plugin-react-swc/CHANGELOG.md
+++ b/packages/plugin-react-swc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Use `optimizeDeps.rollupOptions` instead of `optimizeDeps.esbuildOptions` for rolldown-vite [#489](https://github.com/vitejs/vite-plugin-react/pull/489)
+
+This suppresses the warning about `optimizeDeps.esbuildOptions` being deprecated in rolldown-vite.
+
 ## 3.10.1 (2025-06-03)
 
 ### Add explicit semicolon in preambleCode [#485](https://github.com/vitejs/vite-plugin-react/pull/485)

--- a/packages/plugin-react-swc/README.md
+++ b/packages/plugin-react-swc/README.md
@@ -119,7 +119,7 @@ react({
 
 ### disableOxcRecommendation
 
-If set, disables the recommendation to use `vite-plugin-react-oxc` (which is shown when `rolldown-vite` is detected and neither `swc` plugins are used nor the `swc` options are mutated).
+If set, disables the recommendation to use `@vitejs/plugin-react-oxc` (which is shown when `rolldown-vite` is detected and neither `swc` plugins are used nor the `swc` options are mutated).
 
 ```ts
 react({ disableOxcRecommendation: true })

--- a/packages/plugin-react-swc/README.md
+++ b/packages/plugin-react-swc/README.md
@@ -117,6 +117,14 @@ react({
 })
 ```
 
+### disableOxcRecommendation
+
+If set, disables the recommendation to use `vite-plugin-react-oxc` (which is shown when `rolldown-vite` is detected and neither `swc` plugins are used nor the `swc` options are mutated).
+
+```ts
+react({ disableOxcRecommendation: true })
+```
+
 ## Consistent components exports
 
 For React refresh to work correctly, your file should only export React components. The best explanation I've read is the one from the [Gatsby docs](https://www.gatsbyjs.com/docs/reference/local-development/fast-refresh/#how-it-works).

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -153,12 +153,13 @@ const react = (_options?: Options): PluginOption[] => {
          * Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used and:
          * No swc plugins are set
          * mutateSwcOptions is not set
+         * It is not disabled by the user
          */
         if (
           'rolldownVersion' in vite &&
-          !options.disableOxcRecommendation &&
+          !options.plugins &&
           !options.useAtYourOwnRisk_mutateSwcOptions &&
-          !options.plugins
+          !options.disableOxcRecommendation
         ) {
           config.logger.warn(
             '[vite:react-swc] We recommend switching to `vite-plugin-react-oxc` for improved performance as no swc plugins are used. More information at https://vite.dev/rolldown',

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -12,6 +12,7 @@ import {
   transform,
 } from '@swc/core'
 import type { PluginOption } from 'vite'
+import * as vite from 'vite'
 import {
   addRefreshWrapper,
   getPreambleCode,
@@ -124,7 +125,9 @@ const react = (_options?: Options): PluginOption[] => {
         oxc: false,
         optimizeDeps: {
           include: [`${options.jsxImportSource}/jsx-dev-runtime`],
-          esbuildOptions: { jsx: 'automatic' },
+          ...('rolldownVersion' in vite
+            ? { rollupOptions: { jsx: { mode: 'automatic' } } }
+            : { esbuildOptions: { jsx: 'automatic' } }),
         },
       }),
       configResolved(config) {

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -78,7 +78,7 @@ type Options = {
   useAtYourOwnRisk_mutateSwcOptions?: (options: SWCOptions) => void
 
   /**
-   * If set, disables the recommendation to use `@vitejs/plugin-react-oxc`
+   * If set, disables the recommendation to use `vite-plugin-react-oxc`
    */
   disableOxcRecommendation?: boolean
 }
@@ -160,7 +160,7 @@ const react = (_options?: Options): PluginOption[] => {
           !options.useAtYourOwnRisk_mutateSwcOptions &&
           !options.plugins
         ) {
-          console.warn(
+          config.logger.warn(
             '[vite:react-swc] We recommend switching to `vite-plugin-react-oxc` for improved performance as no swc plugins are used. More information at https://vite.dev/rolldown',
           )
         }

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -76,6 +76,11 @@ type Options = {
    * feature doesn't work is not fun, so we won't provide support for it, hence the name `useAtYourOwnRisk`
    */
   useAtYourOwnRisk_mutateSwcOptions?: (options: SWCOptions) => void
+
+  /**
+   * If set, disables the recommendation to use `vite-plugin-react-oxc`
+   */
+  disableOxcRecommendation?: boolean
 }
 
 const react = (_options?: Options): PluginOption[] => {
@@ -91,6 +96,7 @@ const react = (_options?: Options): PluginOption[] => {
     reactRefreshHost: _options?.reactRefreshHost,
     useAtYourOwnRisk_mutateSwcOptions:
       _options?.useAtYourOwnRisk_mutateSwcOptions,
+    disableOxcRecommendation: _options?.disableOxcRecommendation,
   }
 
   return [
@@ -143,12 +149,14 @@ const react = (_options?: Options): PluginOption[] => {
           )
         }
 
-        /* Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used and:
+        /*
+         * Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used and:
          * No swc plugins are set
          * mutateSwcOptions is not set
          */
         if (
           'rolldownVersion' in vite &&
+          !options.disableOxcRecommendation &&
           !options.useAtYourOwnRisk_mutateSwcOptions &&
           !options.plugins
         ) {

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -78,7 +78,7 @@ type Options = {
   useAtYourOwnRisk_mutateSwcOptions?: (options: SWCOptions) => void
 
   /**
-   * If set, disables the recommendation to use `vite-plugin-react-oxc`
+   * If set, disables the recommendation to use `@vitejs/plugin-react-oxc`
    */
   disableOxcRecommendation?: boolean
 }

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -18,6 +18,7 @@ import {
   runtimePublicPath,
   silenceUseClientWarning,
 } from '@vitejs/react-common'
+import * as vite from 'vite'
 import { exactRegex } from '@rolldown/pluginutils'
 
 /* eslint-disable no-restricted-globals */
@@ -139,6 +140,13 @@ const react = (_options?: Options): PluginOption[] => {
         ) {
           throw new Error(
             '[vite:react-swc] The MDX plugin should be placed before this plugin',
+          )
+        }
+
+        // Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used and no swc plugins are set
+        if ('rolldownVersion' in vite && !config.plugins.length) {
+          console.warn(
+            '[vite:react-swc] We recommend switching to `vite-plugin-react-oxc` for improved performance as no swc plugins are used. More information at https://vite.dev/rolldown',
           )
         }
       },

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -143,8 +143,15 @@ const react = (_options?: Options): PluginOption[] => {
           )
         }
 
-        // Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used and no swc plugins are set
-        if ('rolldownVersion' in vite && !config.plugins.length) {
+        /* Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used and:
+         * No swc plugins are set
+         * mutateSwcOptions is not set
+         */
+        if (
+          'rolldownVersion' in vite &&
+          !options.useAtYourOwnRisk_mutateSwcOptions &&
+          !options.plugins
+        ) {
           console.warn(
             '[vite:react-swc] We recommend switching to `vite-plugin-react-oxc` for improved performance as no swc plugins are used. More information at https://vite.dev/rolldown',
           )

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -12,7 +12,6 @@ import {
   transform,
 } from '@swc/core'
 import type { PluginOption } from 'vite'
-import * as vite from 'vite'
 import {
   addRefreshWrapper,
   getPreambleCode,

--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Use `optimizeDeps.rollupOptions` instead of `optimizeDeps.esbuildOptions` for rolldown-vite [#489](https://github.com/vitejs/vite-plugin-react/pull/489)
+
+This suppresses the warning about `optimizeDeps.esbuildOptions` being deprecated in rolldown-vite.
+
 ## 4.5.1 (2025-06-03)
 
 ### Add explicit semicolon in preambleCode [#485](https://github.com/vitejs/vite-plugin-react/pull/485)

--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -131,7 +131,7 @@ Uncaught Error: @vitejs/plugin-react can't detect preamble. Something is wrong.
 
 ### disableOxcRecommendation
 
-If set, disables the recommendation to use `vite-plugin-react-oxc` (which is shown when `rolldown-vite` is detected and `babel` is not configured).
+If set, disables the recommendation to use `@vitejs/plugin-react-oxc` (which is shown when `rolldown-vite` is detected and `babel` is not configured).
 
 ## Consistent components exports
 

--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -129,6 +129,10 @@ Otherwise, you'll probably get this error:
 Uncaught Error: @vitejs/plugin-react can't detect preamble. Something is wrong.
 ```
 
+### disableOxcRecommendation
+
+If set, disables the recommendation to use `vite-plugin-react-oxc` (which is shown when `rolldown-vite` is detected and `babel` is not configured).
+
 ## Consistent components exports
 
 For React refresh to work correctly, your file should only export React components. You can find a good explanation in the [Gatsby docs](https://www.gatsbyjs.com/docs/reference/local-development/fast-refresh/#how-it-works).

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -131,6 +131,12 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     name: 'vite:react-babel',
     enforce: 'pre',
     config() {
+      if ('rolldownVersion' in vite) {
+        // Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used
+        console.warn(
+          '[vite:react-babel] We recommend switching to `vite-plugin-react-oxc` for improved performance. More information at https://vite.dev/rolldown',
+        )
+      }
       if (opts.jsxRuntime === 'classic') {
         if ('rolldownVersion' in vite) {
           return {

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -62,6 +62,11 @@ export interface Options {
    * reactRefreshHost: 'http://localhost:3000'
    */
   reactRefreshHost?: string
+
+  /**
+   * If set, disables the recommendation to use `vite-plugin-react-oxc`
+   */
+  disableOxcRecommendation?: boolean
 }
 
 export type BabelOptions = Omit<
@@ -131,7 +136,11 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     name: 'vite:react-babel',
     enforce: 'pre',
     config() {
-      if ('rolldownVersion' in vite && !opts.babel) {
+      if (
+        'rolldownVersion' in vite &&
+        !opts.disableOxcRecommendation &&
+        !opts.babel
+      ) {
         // Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used and no babel config is set
         console.warn(
           '[vite:react-babel] We recommend switching to `vite-plugin-react-oxc` for improved performance. More information at https://vite.dev/rolldown',

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -174,17 +174,6 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         config.command === 'build' ||
         config.server.hmr === false
 
-      if (
-        'rolldownVersion' in vite &&
-        !opts.disableOxcRecommendation &&
-        !opts.babel
-      ) {
-        // Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used and no babel config is set
-        config.logger.warn(
-          '[vite:react-babel] We recommend switching to `vite-plugin-react-oxc` for improved performance. More information at https://vite.dev/rolldown',
-        )
-      }
-
       if ('jsxPure' in opts) {
         config.logger.warnOnce(
           '[@vitejs/plugin-react] jsxPure was removed. You can configure esbuild.jsxSideEffects directly.',
@@ -194,6 +183,23 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
       const hooks: ReactBabelHook[] = config.plugins
         .map((plugin) => plugin.api?.reactBabel)
         .filter(defined)
+
+      if (
+        'rolldownVersion' in vite &&
+        !opts.babel &&
+        !hooks.length &&
+        !opts.disableOxcRecommendation
+      ) {
+        /*
+         * Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used and:
+         * No babel config is set
+         * No other plugin is using the `api.reactBabel` hook
+         * It is not disabled by the user
+         */
+        config.logger.warn(
+          '[vite:react-babel] We recommend switching to `vite-plugin-react-oxc` for improved performance. More information at https://vite.dev/rolldown',
+        )
+      }
 
       if (hooks.length > 0) {
         runPluginOverrides = (babelOptions, context) => {

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -64,7 +64,7 @@ export interface Options {
   reactRefreshHost?: string
 
   /**
-   * If set, disables the recommendation to use `vite-plugin-react-oxc`
+   * If set, disables the recommendation to use `@vitejs/plugin-react-oxc`
    */
   disableOxcRecommendation?: boolean
 }

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -131,8 +131,8 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     name: 'vite:react-babel',
     enforce: 'pre',
     config() {
-      if ('rolldownVersion' in vite) {
-        // Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used
+      if ('rolldownVersion' in vite && !opts.babel) {
+        // Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used and no babel config is set
         console.warn(
           '[vite:react-babel] We recommend switching to `vite-plugin-react-oxc` for improved performance. More information at https://vite.dev/rolldown',
         )

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -64,7 +64,7 @@ export interface Options {
   reactRefreshHost?: string
 
   /**
-   * If set, disables the recommendation to use `@vitejs/plugin-react-oxc`
+   * If set, disables the recommendation to use `vite-plugin-react-oxc`
    */
   disableOxcRecommendation?: boolean
 }
@@ -136,16 +136,6 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     name: 'vite:react-babel',
     enforce: 'pre',
     config() {
-      if (
-        'rolldownVersion' in vite &&
-        !opts.disableOxcRecommendation &&
-        !opts.babel
-      ) {
-        // Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used and no babel config is set
-        console.warn(
-          '[vite:react-babel] We recommend switching to `vite-plugin-react-oxc` for improved performance. More information at https://vite.dev/rolldown',
-        )
-      }
       if (opts.jsxRuntime === 'classic') {
         if ('rolldownVersion' in vite) {
           return {
@@ -183,6 +173,17 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         isProduction ||
         config.command === 'build' ||
         config.server.hmr === false
+
+      if (
+        'rolldownVersion' in vite &&
+        !opts.disableOxcRecommendation &&
+        !opts.babel
+      ) {
+        // Suggest to use vite-plugin-react-oxc if `rolldown-vite` is used and no babel config is set
+        config.logger.warn(
+          '[vite:react-babel] We recommend switching to `vite-plugin-react-oxc` for improved performance. More information at https://vite.dev/rolldown',
+        )
+      }
 
       if ('jsxPure' in opts) {
         config.logger.warnOnce(

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -157,7 +157,10 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
             jsx: 'automatic',
             jsxImportSource: opts.jsxImportSource,
           },
-          optimizeDeps: { esbuildOptions: { jsx: 'automatic' } },
+          optimizeDeps:
+            'rolldownVersion' in vite
+              ? { rollupOptions: { jsx: { mode: 'automatic' } } }
+              : { esbuildOptions: { jsx: 'automatic' } },
         }
       }
     },


### PR DESCRIPTION
### Description

This PR introduces a log (warn) when using `rolldown-vite` and either:

* `vite-plugin-react`,
* or `vite-plugin-react-swc` (without any `swc` plugins set)

It recommends using `vite-plugin-react-oxc` and links to the Rolldown migration guide.

I'm planning on adding info regardinvg `vite-plugin-react-oxc` to it in another PR
